### PR TITLE
Make parseValue work for string-vector

### DIFF
--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -232,7 +232,7 @@ class CLIParameter(object):
 
     def parseValue(self, value):
         """Parse the given value and return result."""
-        if self.isNumericVector() or self.typ == 'string-vector':
+        if self.isVector():
             return map(self._pythonType, value.split(','))
         if self.typ == 'boolean':
             return _parseBool(value)

--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -241,6 +241,9 @@ class CLIParameter(object):
     def isOptional(self):
         return self.index is None
 
+    def isVector(self):
+        return self.isNumericVector() or self.typ == 'string-vector'
+
     def isNumericVector(self):
         """Return whether this is a vector-like type with multiple
         elements of a numeric type.  This includes the numeric

--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -176,7 +176,8 @@ class CLIParameter(object):
         'string', 'directory',
         'integer-vector', 'float-vector', 'double-vector',
         'string-vector',
-        'integer-enumeration', 'float-enumeration', 'double-enumeration', 'string-enumeration',
+        'integer-enumeration', 'float-enumeration', 'double-enumeration',
+        'string-enumeration',
         'point', 'region',
         'file',
     )
@@ -198,11 +199,12 @@ class CLIParameter(object):
         'integer' : int,
         'float' : float,
         'double' : float,
+        'string' : str
     }
 
     REQUIRED_ELEMENTS = ('name', 'description', 'label')
 
-    OPTIONAL_ELEMENTS = (# either 'flag' or 'longflag' (or both) or 'index' are required
+    OPTIONAL_ELEMENTS = (# either 'index' or atleast one of 'flag' or 'longflag' is required
                          'flag', 'longflag', 'index',
                          'default', 'channel')
     
@@ -230,7 +232,7 @@ class CLIParameter(object):
 
     def parseValue(self, value):
         """Parse the given value and return result."""
-        if self.isNumericVector():
+        if self.isNumericVector() or self.typ == 'string-vector':
             return map(self._pythonType, value.split(','))
         if self.typ == 'boolean':
             return _parseBool(value)

--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -204,7 +204,7 @@ class CLIParameter(object):
 
     REQUIRED_ELEMENTS = ('name', 'description', 'label')
 
-    OPTIONAL_ELEMENTS = (# either 'index' or atleast one of 'flag' or 'longflag' is required
+    OPTIONAL_ELEMENTS = (# either 'index' or at least one of 'flag' or 'longflag' is required
                          'flag', 'longflag', 'index',
                          'default', 'channel')
     


### PR DESCRIPTION
Made CLIParameter.parseValue work for parameters of type string-vector and made minor style fixes.

@jcfr and @hmeine can you please take a look?

In the next pull request (which requires this change), i am about to add a module with a class called CLIArgumentParser that derives from argparse.ArgumentParser and does command-line argument parsing similar to [GenerateCLP of SlicerExecutionModel](https://github.com/Slicer/SlicerExecutionModel/tree/master/GenerateCLP).
