### PR TITLE
BUG: Return empty list for empty default tag for vector parameter

### DIFF
--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -347,6 +347,8 @@ class CLIParameter(object):
             except ValueError, e:
                 logger.warning('Could not parse default value of <%s> (%s): %s' % (
                     _tag(elementTree), self.name, e))
+        elif self.isVector():
+            self.default = list()
 
         if self.typ.endswith('-enumeration'):
             try:


### PR DESCRIPTION
When the default value for a parameter that is a vector is not set
or set to nothing, it should be configured as an empty list, not
an empty string. If ctk_cli returns an empty string, the parsing
of the default value will result in an error.
