### PR TITLE
Improve Python 3 compatibility

### DIFF
--- a/ctk_cli/__init__.py
+++ b/ctk_cli/__init__.py
@@ -1,4 +1,4 @@
-from module import CLIModule
-from execution import (getXMLDescription, isCLIExecutable,
+from .module import CLIModule
+from .execution import (getXMLDescription, isCLIExecutable,
                        listCLIExecutables, popenCLIExecutable)
-from argument_parser import CLIArgumentParser
+from .argument_parser import CLIArgumentParser

--- a/ctk_cli/argument_parser.py
+++ b/ctk_cli/argument_parser.py
@@ -40,7 +40,7 @@ def _make_print_xml_action(xml_spec_file):
                 help=help)
 
         def __call__(self, parser, namespace, values, option_string=None):
-            print str_xml
+            print(str_xml)
             parser.exit()
 
     return _PrintXMLAction

--- a/ctk_cli/execution.py
+++ b/ctk_cli/execution.py
@@ -86,7 +86,7 @@ def getXMLDescription(cliExecutable, **kwargs):
             for line in f:
                 logger.warning('%s: %s' % (os.path.basename(cliExecutable), line[:-1]))
         if ec:
-            raise RuntimeError, "Calling %s failed (exit code %d)" % (cliExecutable, ec)
+            raise RuntimeError("Calling %s failed (exit code %d)" % (cliExecutable, ec))
         with file(stdoutFilename) as f:
             return ET.parse(f)
     finally:

--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -3,7 +3,7 @@
 
 import os, logging
 import xml.etree.ElementTree as ET
-from execution import isCLIExecutable, getXMLDescription
+from .execution import isCLIExecutable, getXMLDescription
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ def _parseBool(x):
         return True
     if x in ('false', 'False', '0'):
         return False
-    raise ValueError, "cannot convert %r to boolean" % (x, )
+    raise ValueError("cannot convert %r to boolean" % (x, ))
 
 def _tag(element):
     """Return element.tag with xmlns stripped away."""
@@ -226,7 +226,7 @@ class CLIParameter(object):
     def identifier(self):
         result = self.name if self.name else self.longflag.lstrip('-')
         if not result:
-            raise RuntimeError, "Cannot identify parameter either by name or by longflag (both missing)"
+            raise RuntimeError("Cannot identify parameter either by name or by longflag (both missing)")
         return result
 
     def parseValue(self, value):
@@ -344,14 +344,14 @@ class CLIParameter(object):
         if self.default:
             try:
                 self.default = self.parseValue(self.default)
-            except ValueError, e:
+            except ValueError as e:
                 logger.warning('Could not parse default value of <%s> (%s): %s' % (
                     _tag(elementTree), self.name, e))
 
         if self.typ.endswith('-enumeration'):
             try:
                 self.elements = map(self.parseValue, elements)
-            except ValueError, e:
+            except ValueError as e:
                 logger.warning('Problem parsing enumeration element values of <%s> (%s): %s' % (
                     _tag(elementTree), self.name, e))
             if not elements:


### PR DESCRIPTION
Changes required for 'import ctk_cli' to work with Python 3.5.2.