### PR TITLE
Create MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.rst
+include LICENSE_Apache_20


### PR DESCRIPTION
Hey-lo,

I'm [building a version](https://github.com/conda-forge/staged-recipes/pull/2662) of `ctk-cli` using [`conda`](http://conda.pydata.org/) for [conda-forge](http://conda-forge.github.io/). When possible, we try to include a link to the license file in the `meta.yaml` specification for the build; doing so requires the license be indexed in an explicit [`MANIFEST.in`](https://docs.python.org/2/distutils/sourcedist.html#manifest-related-options) file so that it gets included in the source distribution.

This pull would create just such a manifest, and should guarantee that the license is included in future builds. Would you consider adding it?