### PR TITLE
Support multiple executables in a single XML document

### DIFF
--- a/ctk_cli/module.py
+++ b/ctk_cli/module.py
@@ -165,6 +165,9 @@ class CLIModule(list):
     # factory method from the outside, even if the signature and
     # content is really similar:
     def _parse(self, elementTree):
+        if 'path' in elementTree.attrib:
+            self.path = elementTree.attrib['path']
+
         childNodes = _parseElements(self, elementTree, 'executable')
 
         for pnode in childNodes:


### PR DESCRIPTION
This adds the `CLIModuleList` class that is designed to support a new level of nesting to allow multiple CLI modules to be expressed in a single XML document.

Before, the root element was always `<executable>`, but if using this new class, a root element tag `<executables>` is also supported, which can contain multiple `<executable>` children.

ping @jcfr @cdeepakroy